### PR TITLE
Feature/fem 1900 add authenticator

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.0'
+    ext.kotlin_version = '1.2.21'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0-beta2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 13 15:44:17 CET 2017
+#Mon Feb 12 16:58:25 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/network/build.gradle
+++ b/network/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'com.android.support:support-annotations:27.0.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     api 'com.squareup.okhttp3:okhttp:3.9.1'
 }
 

--- a/network/src/main/AndroidManifest.xml
+++ b/network/src/main/AndroidManifest.xml
@@ -1,2 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.stanwood.framework.network" />
+    package="io.stanwood.framework.network" >
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/network/src/main/java/io/stanwood/framework/network/auth/AnonymousAuthenticator.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/AnonymousAuthenticator.java
@@ -1,0 +1,91 @@
+package io.stanwood.framework.network.auth;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.io.IOException;
+
+import io.stanwood.framework.network.util.ConnectionState;
+import okhttp3.Authenticator;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
+
+/**
+ * This class will be called by okhttp upon receiving a 401 from the server which means we should
+ * usually retry the request with a fresh token.
+ *
+ * It is NOT called for during initially making a request. For that refer to
+ * {@link AnonymousAuthInterceptor}.
+ */
+public abstract class AnonymousAuthenticator implements Authenticator {
+
+    private final AuthenticationService authenticationService;
+    private final ConnectionState connectionState;
+    private final TokenReaderWriter tokenReaderWriter;
+
+    public AnonymousAuthenticator(
+            @NonNull Context applicationContext,
+            @NonNull AuthenticationService authenticationService,
+            @NonNull TokenReaderWriter tokenReaderWriter
+    ) {
+       this.authenticationService = authenticationService;
+       this.connectionState = new ConnectionState(applicationContext);
+       this.tokenReaderWriter = tokenReaderWriter;
+    }
+
+    @Override
+    public Request authenticate(@NonNull Route route, @NonNull Response response) throws IOException {
+        Request request = response.request();
+
+        String oldToken = tokenReaderWriter.read(request);
+        if (oldToken != null) {
+            if (request.header(AuthHeaderKeys.RETRY_WITH_REFRESH_HEADER_KEY) != null) {
+                synchronized (AuthenticationService.ANONYMOUS_AUTH_REFRESH_TOKEN_LOCK) {
+                    String token;
+                    try {
+                        token = authenticationService.getAnonymousToken(false);
+                    } catch (Exception e) {
+                        throw new IOException("Error while trying to retrieve auth token: " + e.getMessage(), e);
+                    }
+
+                    if (oldToken.equals(token)) {
+                        /*
+                        if the token we receive from the AuthenticationService hasn't changed in
+                        the meantime (e.g. due to another request having triggered a 401 and
+                        re-authenticating before us getting here), try to get a new one
+                        */
+                        try {
+                            token = authenticationService.getAnonymousToken(true);
+                        } catch (Exception e) {
+                            throw new IOException("Error while trying to retrieve auth token: " + e.getMessage(), e);
+                        }
+                    }
+
+                    return tokenReaderWriter.write(
+                            request.newBuilder()
+                                    .removeHeader(AuthHeaderKeys.RETRY_WITH_REFRESH_HEADER_KEY)
+                                    .build(),
+                            token);
+                }
+            } else {
+                return onAuthenticationFailed(request);
+            }
+        }
+
+        return request;
+    }
+
+    /**
+     * Called upon ultimately failed authentication.
+     * <br><br>
+     * The default implementation just returns {@code null} and thus cancels the request.
+     * @return
+     */
+    @SuppressWarnings("WeakerAccess")
+    @Nullable
+    protected Request onAuthenticationFailed(@NonNull Request request) {
+        return null; // Give up, we've already failed to authenticate even after refreshing the token.
+    }
+}

--- a/network/src/main/java/io/stanwood/framework/network/auth/AuthHeaderKeys.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/AuthHeaderKeys.java
@@ -1,8 +1,11 @@
 package io.stanwood.framework.network.auth;
 
+import io.stanwood.framework.network.auth.anonymous.AnonymousAuthInterceptor;
+import io.stanwood.framework.network.auth.anonymous.AnonymousAuthenticator;
+
 /**
- * A collection of header keys used by {@link AuthInterceptor} AND {@link AnonymousAuthenticator} as
- * well as their signed-in variants.
+ * A collection of header keys used by {@link AnonymousAuthInterceptor} AND {@link AnonymousAuthenticator}
+ * as well as their signed-in variants.
  */
 @SuppressWarnings("WeakerAccess")
 public abstract class AuthHeaderKeys {
@@ -11,5 +14,5 @@ public abstract class AuthHeaderKeys {
      * This header is set by the Authenticators / Auth Interceptors to determine when to retry a
      * request with a fresh token.
      */
-    static final String RETRY_WITH_REFRESH_HEADER_KEY = "RetryWithRefresh";
+    public static final String RETRY_WITH_REFRESH_HEADER_KEY = "RetryWithRefresh";
 }

--- a/network/src/main/java/io/stanwood/framework/network/auth/AuthHeaderKeys.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/AuthHeaderKeys.java
@@ -1,0 +1,15 @@
+package io.stanwood.framework.network.auth;
+
+/**
+ * A collection of header keys used by {@link AuthInterceptor} AND {@link AnonymousAuthenticator} as
+ * well as their signed-in variants.
+ */
+@SuppressWarnings("WeakerAccess")
+public abstract class AuthHeaderKeys {
+
+    /**
+     * This header is set by the Authenticators / Auth Interceptors to determine when to retry a
+     * request with a fresh token.
+     */
+    static final String RETRY_WITH_REFRESH_HEADER_KEY = "RetryWithRefresh";
+}

--- a/network/src/main/java/io/stanwood/framework/network/auth/AuthenticationService.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/AuthenticationService.java
@@ -5,9 +5,16 @@ import java.io.IOException;
 public interface AuthenticationService {
 
     /**
-     * Lock used by anonymous Authenticator / Auth Interceptor when requesting tokens
+     * Lock used by anonymous Authenticator / Auth Interceptor when requesting tokens. Provide a
+     * final static Object here.
      */
-    Object ANONYMOUS_AUTH_REFRESH_TOKEN_LOCK = new Object();
+    Object getAnonymousLock();
+
+    /**
+     * Lock used by anonymous Authenticator / Auth Interceptor when requesting tokens. Provide a
+     * final static Object here.
+     */
+    Object getAuthenticatedLock();
 
     /**
      * Retrieves a token for authenticated access

--- a/network/src/main/java/io/stanwood/framework/network/auth/AuthenticationService.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/AuthenticationService.java
@@ -31,4 +31,11 @@ public interface AuthenticationService {
      * @return whether the user is logged in
      */
     boolean isUserSignedIn();
+
+    /**
+     * Signs out the user.
+     * <br><br>
+     * Called when authentication fails permanently while being in authenticated mode.
+     */
+    void signOut();
 }

--- a/network/src/main/java/io/stanwood/framework/network/auth/AuthenticationService.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/AuthenticationService.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 public interface AuthenticationService {
 
     /**
-     * Lock used by Authenticator / Auth Interceptor when requesting tokens
+     * Lock used by anonymous Authenticator / Auth Interceptor when requesting tokens
      */
     Object ANONYMOUS_AUTH_REFRESH_TOKEN_LOCK = new Object();
 

--- a/network/src/main/java/io/stanwood/framework/network/auth/AuthenticationService.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/AuthenticationService.java
@@ -1,0 +1,34 @@
+package io.stanwood.framework.network.auth;
+
+import java.io.IOException;
+
+public interface AuthenticationService {
+
+    /**
+     * Lock used by Authenticator / Auth Interceptor when requesting tokens
+     */
+    Object ANONYMOUS_AUTH_REFRESH_TOKEN_LOCK = new Object();
+
+    /**
+     * Retrieves a token for authenticated access
+     *
+     * @param forceRefresh whether a new token shall be retrieved from the server and not from cache
+     * @return token
+     */
+    String getToken(boolean forceRefresh);
+
+    /**
+     * Retrieves a token for unauthenticated access
+     *
+     * @param forceRefresh whether a new token shall be retrieved from the server and not from cache
+     * @return token
+     */
+    String getAnonymousToken(boolean forceRefresh) throws IOException;
+
+    /**
+     * Checks whether the user is logged in (not anonymously!).
+     *
+     * @return whether the user is logged in
+     */
+    boolean isUserSignedIn();
+}

--- a/network/src/main/java/io/stanwood/framework/network/auth/TokenReaderWriter.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/TokenReaderWriter.java
@@ -1,5 +1,6 @@
 package io.stanwood.framework.network.auth;
 
+import io.stanwood.framework.network.auth.anonymous.AnonymousAuthenticator;
 import okhttp3.Request;
 
 /**
@@ -26,11 +27,19 @@ public interface TokenReaderWriter {
     /**
      * Writes a token to the request (most probably either to a header or as an URL parameter.
      * <br><br>
-     * Ensure to delete/override any existing tokens!
+     * You don't need to explicitly remove possibly existing tokens as {@link #removeToken(Request)}
+     * will be called for you before.
      *
      * @param request okhttp Request
      * @param token the token to write
-     * @return
+     * @return the Request with token
      */
     Request write(Request request, String token);
+
+    /**
+     * Removes the token from the given request.
+     * @param request okhttp Request
+     * @return the Request without token
+     */
+    Request removeToken(Request request);
 }

--- a/network/src/main/java/io/stanwood/framework/network/auth/TokenReaderWriter.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/TokenReaderWriter.java
@@ -1,0 +1,36 @@
+package io.stanwood.framework.network.auth;
+
+import okhttp3.Request;
+
+/**
+ * Reads and writes tokens from/to okhttp requests.
+ *
+ * @see AnonymousAuthenticator
+ */
+public interface TokenReaderWriter {
+
+    /**
+     * Reads a token from a given request.
+     * <br><br>
+     * This is mainly used to compare the token we sent with the
+     * one we have available via the {@link AuthenticationService} to check whether it has changed
+     * since we issued the request or whether we should try to get a new token.
+     * <br><br>
+     * Note, that this is NOT to read the token the server returns you when requesting a new one!
+     *
+     * @param request okhttp Request
+     * @return the token found in the request
+     */
+    String read(Request request);
+
+    /**
+     * Writes a token to the request (most probably either to a header or as an URL parameter.
+     * <br><br>
+     * Ensure to delete/override any existing tokens!
+     *
+     * @param request okhttp Request
+     * @param token the token to write
+     * @return
+     */
+    Request write(Request request, String token);
+}

--- a/network/src/main/java/io/stanwood/framework/network/auth/anonymous/AnonymousAuthInterceptor.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/anonymous/AnonymousAuthInterceptor.java
@@ -50,7 +50,7 @@ public class AnonymousAuthInterceptor implements Interceptor {
 
         if (connectionState.isConnected()) {
             String token;
-            synchronized (AuthenticationService.ANONYMOUS_AUTH_REFRESH_TOKEN_LOCK) {
+            synchronized (authenticationService.getAnonymousLock()) {
                 try {
                     token = authenticationService.getAnonymousToken(false);
                 } catch (Exception e) {

--- a/network/src/main/java/io/stanwood/framework/network/auth/anonymous/AnonymousAuthInterceptor.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/anonymous/AnonymousAuthInterceptor.java
@@ -15,8 +15,12 @@ import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
+/**
+ * This class is used by okhttp to anonymously authenticate requests.
+ */
 public class AnonymousAuthInterceptor implements Interceptor {
 
+    @NonNull
     private final ConnectionState connectionState;
     @NonNull
     private final AuthenticationService authenticationService;

--- a/network/src/main/java/io/stanwood/framework/network/auth/anonymous/AnonymousAuthInterceptor.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/anonymous/AnonymousAuthInterceptor.java
@@ -1,0 +1,65 @@
+package io.stanwood.framework.network.auth.anonymous;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import java.io.IOException;
+
+import io.stanwood.framework.network.auth.AuthHeaderKeys;
+import io.stanwood.framework.network.auth.AuthenticationService;
+import io.stanwood.framework.network.auth.TokenReaderWriter;
+import io.stanwood.framework.network.util.ConnectionState;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class AnonymousAuthInterceptor implements Interceptor {
+
+    private final ConnectionState connectionState;
+    @NonNull
+    private final AuthenticationService authenticationService;
+    @NonNull
+    private final TokenReaderWriter tokenReaderWriter;
+
+    public AnonymousAuthInterceptor(
+            @NonNull Context applicationContext,
+            @NonNull AuthenticationService authenticationService,
+            @NonNull TokenReaderWriter tokenReaderWriter
+    ) {
+        this.connectionState = new ConnectionState(applicationContext);
+        this.authenticationService = authenticationService;
+        this.tokenReaderWriter = tokenReaderWriter;
+    }
+
+    private Request getRequest(
+            @NonNull Request request,
+            @NonNull AuthenticationService authenticationService
+    ) throws IOException {
+        final Request.Builder requestBuilder = request.newBuilder();
+        request = tokenReaderWriter.removeToken(request);
+
+        if (connectionState.isConnected()) {
+            String token;
+            synchronized (AuthenticationService.ANONYMOUS_AUTH_REFRESH_TOKEN_LOCK) {
+                try {
+                    token = authenticationService.getAnonymousToken(false);
+                } catch (Exception e) {
+                    throw new IOException("Error while trying to retrieve Firebase auth token: " + e.getMessage(), e);
+                }
+            }
+            requestBuilder.header(AuthHeaderKeys.RETRY_WITH_REFRESH_HEADER_KEY, "true");
+            request = tokenReaderWriter.write(request, token);
+        } else {
+            // we're offline, clean up headers for cache handling
+            requestBuilder.removeHeader(AuthHeaderKeys.RETRY_WITH_REFRESH_HEADER_KEY);
+        }
+        return request;
+    }
+
+    @Override
+    public Response intercept(@NonNull Chain chain) throws IOException {
+        Request request = getRequest(chain.request(), authenticationService);
+
+        return chain.proceed(request);
+    }
+}

--- a/network/src/main/java/io/stanwood/framework/network/auth/anonymous/AnonymousAuthenticator.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/anonymous/AnonymousAuthenticator.java
@@ -66,7 +66,7 @@ public abstract class AnonymousAuthenticator implements Authenticator {
         String oldToken = tokenReaderWriter.read(request);
         if (oldToken != null) {
             if (request.header(AuthHeaderKeys.RETRY_WITH_REFRESH_HEADER_KEY) != null) {
-                synchronized (AuthenticationService.ANONYMOUS_AUTH_REFRESH_TOKEN_LOCK) {
+                synchronized (authenticationService.getAnonymousLock()) {
                     String token;
                     try {
                         token = authenticationService.getAnonymousToken(false);

--- a/network/src/main/java/io/stanwood/framework/network/auth/anonymous/AnonymousAuthenticator.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/anonymous/AnonymousAuthenticator.java
@@ -18,7 +18,7 @@ import okhttp3.Route;
  * This class will be called by okhttp upon receiving a 401 from the server which means we should
  * usually retry the request with a fresh token.
  * <p>
- * It is NOT called for during initially making a request. For that refer to
+ * It is NOT called during initially making a request. For that refer to
  * {@link AnonymousAuthInterceptor}.
  */
 public abstract class AnonymousAuthenticator implements Authenticator {

--- a/network/src/main/java/io/stanwood/framework/network/auth/authenticated/AuthenticatedAuthInterceptor.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/authenticated/AuthenticatedAuthInterceptor.java
@@ -15,6 +15,7 @@ import okhttp3.Response;
 
 public class AuthenticatedAuthInterceptor implements Interceptor {
 
+    @NonNull
     private final ConnectionState connectionState;
     @NonNull
     private final AuthenticationService authenticationService;

--- a/network/src/main/java/io/stanwood/framework/network/auth/authenticated/AuthenticatedAuthInterceptor.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/authenticated/AuthenticatedAuthInterceptor.java
@@ -41,7 +41,7 @@ public class AuthenticatedAuthInterceptor implements Interceptor {
 
         if (connectionState.isConnected()) {
             String token;
-            synchronized (AuthenticationService.ANONYMOUS_AUTH_REFRESH_TOKEN_LOCK) {
+            synchronized (authenticationService.getAuthenticatedLock()) {
                 try {
                     token = authenticationService.getToken(false);
                 } catch (Exception e) {

--- a/network/src/main/java/io/stanwood/framework/network/auth/authenticated/AuthenticatedAuthenticator.java
+++ b/network/src/main/java/io/stanwood/framework/network/auth/authenticated/AuthenticatedAuthenticator.java
@@ -35,7 +35,7 @@ public class AuthenticatedAuthenticator implements Authenticator {
         String oldToken = tokenReaderWriter.read(request);
         if (oldToken != null) {
             if (request.header(AuthHeaderKeys.RETRY_WITH_REFRESH_HEADER_KEY) != null) {
-                synchronized (AuthenticationService.ANONYMOUS_AUTH_REFRESH_TOKEN_LOCK) {
+                synchronized (authenticationService.getAuthenticatedLock()) {
                     String token;
                     try {
                         token = authenticationService.getToken(false);

--- a/network/src/main/java/io/stanwood/framework/network/cache/CacheHeaderKeys.java
+++ b/network/src/main/java/io/stanwood/framework/network/cache/CacheHeaderKeys.java
@@ -7,7 +7,7 @@ package io.stanwood.framework.network.cache;
  * Add any combination of these headers to your requests and the interceptors will pick them up.
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class HeaderKeys {
+public abstract class CacheHeaderKeys {
 
     /**
      * Allows caching this request for offline usage. That doesn't mean it is used as online cache.

--- a/network/src/main/java/io/stanwood/framework/network/cache/CacheInterceptor.java
+++ b/network/src/main/java/io/stanwood/framework/network/cache/CacheInterceptor.java
@@ -1,12 +1,8 @@
 package io.stanwood.framework.network.cache;
 
-import android.Manifest;
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
 
 import java.io.IOException;
 
@@ -64,7 +60,7 @@ public class CacheInterceptor implements Interceptor {
     public Response intercept(@NonNull Chain chain) throws IOException {
         Request request = chain.request();
 
-        String offlineCacheHeader = request.header(HeaderKeys.APPLY_OFFLINE_CACHE);
+        String offlineCacheHeader = request.header(CacheHeaderKeys.APPLY_OFFLINE_CACHE);
         if (Boolean.valueOf(offlineCacheHeader)) {
             if (!connectionState.isConnected()) {
                 Request.Builder builder = request.newBuilder();
@@ -77,14 +73,14 @@ public class CacheInterceptor implements Interceptor {
                 }
                 request = builder
                         .cacheControl(CacheControl.FORCE_CACHE)
-                        .removeHeader(HeaderKeys.APPLY_OFFLINE_CACHE)
-                        .removeHeader(HeaderKeys.APPLY_RESPONSE_CACHE)
+                        .removeHeader(CacheHeaderKeys.APPLY_OFFLINE_CACHE)
+                        .removeHeader(CacheHeaderKeys.APPLY_RESPONSE_CACHE)
                         .build();
                 return chain.proceed(request);
             }
         }
 
-        String responseCacheHeader = request.header(HeaderKeys.REFRESH);
+        String responseCacheHeader = request.header(CacheHeaderKeys.REFRESH);
         if (Boolean.valueOf(responseCacheHeader)) {
             try {
                 return chain.proceed(request.newBuilder().cacheControl(CacheControl.FORCE_NETWORK).build());
@@ -103,8 +99,8 @@ public class CacheInterceptor implements Interceptor {
                 }
                 return chain.proceed(builder
                         .cacheControl(CacheControl.FORCE_CACHE)
-                        .removeHeader(HeaderKeys.APPLY_OFFLINE_CACHE)
-                        .removeHeader(HeaderKeys.APPLY_RESPONSE_CACHE)
+                        .removeHeader(CacheHeaderKeys.APPLY_OFFLINE_CACHE)
+                        .removeHeader(CacheHeaderKeys.APPLY_RESPONSE_CACHE)
                         .build());
             }
         } else {

--- a/network/src/main/java/io/stanwood/framework/network/cache/CacheNetworkInterceptor.java
+++ b/network/src/main/java/io/stanwood/framework/network/cache/CacheNetworkInterceptor.java
@@ -32,7 +32,7 @@ import okhttp3.Response;
  * accepting a list of parameter keys instead of just the one of the auth parameter.
  *
  * <p>Configuration of the interceptor classes is mainly done by means of request headers. Check
- * out {@link HeaderKeys} for more details on what the different headers do.
+ * out {@link CacheHeaderKeys} for more details on what the different headers do.
  *
  * <p>Add it as a network interceptor to your OkHttpClient Builder like so:
  * <pre>
@@ -51,7 +51,7 @@ public class CacheNetworkInterceptor implements Interceptor {
      * @param queryAuthParameterKey the name of any auth query parameter to be removed before caching
      *                             or {@code null} if there is none
      * @param cacheForSeconds seconds for which we should generally cache in case the
-     *                       {@link HeaderKeys#APPLY_RESPONSE_CACHE} is set
+     *                       {@link CacheHeaderKeys#APPLY_RESPONSE_CACHE} is set
      */
     public CacheNetworkInterceptor(@Nullable String queryAuthParameterKey, long cacheForSeconds) {
         this.queryAuthParameterKey = queryAuthParameterKey;
@@ -61,8 +61,8 @@ public class CacheNetworkInterceptor implements Interceptor {
     @Override
     public Response intercept(@NonNull Chain chain) throws IOException {
         Request request = chain.request();
-        String responseCacheHeader = request.header(HeaderKeys.APPLY_RESPONSE_CACHE);
-        String offlineCacheHeader = request.header(HeaderKeys.APPLY_OFFLINE_CACHE);
+        String responseCacheHeader = request.header(CacheHeaderKeys.APPLY_RESPONSE_CACHE);
+        String offlineCacheHeader = request.header(CacheHeaderKeys.APPLY_OFFLINE_CACHE);
         boolean isGeneralCache = Boolean.valueOf(responseCacheHeader);
         boolean isOfflineCache = Boolean.valueOf(offlineCacheHeader);
         if (isGeneralCache || isOfflineCache) {

--- a/network/src/main/java/io/stanwood/framework/network/util/ConnectionState.java
+++ b/network/src/main/java/io/stanwood/framework/network/util/ConnectionState.java
@@ -1,0 +1,20 @@
+package io.stanwood.framework.network.util;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+public class ConnectionState {
+
+    private ConnectivityManager connectivityManager;
+
+    public ConnectionState(Context applicationContext) {
+        connectivityManager = (ConnectivityManager) applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+    }
+
+    public boolean isConnected() {
+        NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
+        return activeNetwork != null && activeNetwork.isConnectedOrConnecting();
+    }
+
+}


### PR DESCRIPTION
Adds generic anonymous and authenticated authenticators/interceptors for usage with okhttp. Hopefully this eases writing reliable authentication in all our apps. First iteration, architecture most probably not final yet. More documentation, examples as well as implementations for common token providers will be implemented later on when I've evaluated the lib with SNH and FEM.